### PR TITLE
Fix the address prefixes argument for the subnets

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -22,6 +22,6 @@ resource "azurerm_subnet" "module" {
   count                = length(var.subnet_address_prefixes)
   resource_group_name  = azurerm_resource_group.module.name
   virtual_network_name = azurerm_virtual_network.module.name
-  address_prefixes       = var.subnet_address_prefixes[count.index]
+  address_prefixes       = [var.subnet_address_prefixes[count.index]]
 }
 

--- a/main.tf
+++ b/main.tf
@@ -22,6 +22,6 @@ resource "azurerm_subnet" "module" {
   count                = length(var.subnet_address_prefixes)
   resource_group_name  = azurerm_resource_group.module.name
   virtual_network_name = azurerm_virtual_network.module.name
-  address_prefix       = var.subnet_address_prefixes[count.index]
+  address_prefixes       = var.subnet_address_prefixes[count.index]
 }
 

--- a/main.tf
+++ b/main.tf
@@ -14,6 +14,7 @@ resource "azurerm_virtual_network" "module" {
   resource_group_name = azurerm_resource_group.module.name
   tags = {
     environment = "dev"
+    moduleVersion = "dummy"
   }
 }
 

--- a/main.tf
+++ b/main.tf
@@ -3,7 +3,7 @@ resource "azurerm_resource_group" "module" {
   location = var.location
   tags = {
     environment = "dev"
-    version     = "v0.12.0"
+    version     = "v1.0.0"
   }
 }
 


### PR DESCRIPTION
Update the `azurerm_subnet` resource to use `address_prefixes` instead of `address_prefix`.